### PR TITLE
Handle end of pagination

### DIFF
--- a/src/fbconsole.py
+++ b/src/fbconsole.py
@@ -602,7 +602,10 @@ def iter_pages(json_response):
     while len(json_response.get('data','')):
         for item in json_response['data']:
             yield item
-        next_url = json_response['paging']['next']
+        try:
+            next_url = json_response['paging']['next']
+        except KeyError:
+            break
         json_response = _safe_json_load(next_url)
 
 def post(path, params=None):


### PR DESCRIPTION
`iter_pages` crashes when attempting to paginate past the final page.
`next_url = json_response['paging']['next']` has a `KeyError` when the
json response lacks a `next` key. The `next` key is not included if this
is the last page of data.

https://developers.facebook.com/docs/reference/api/pagination/
